### PR TITLE
Really copy apt configuration files into /etc/apt/.

### DIFF
--- a/container/build.containerfile
+++ b/container/build.containerfile
@@ -17,7 +17,7 @@ FROM $arch/$image
 WORKDIR /tmp
 
 # Copy repository configration files for apt 
-COPY container/apt /etc/
+COPY container/apt/ /etc/apt/
 
 # Create a directory for local packages and touch the Packages file
 RUN mkdir /pkgs && touch /pkgs/Packages

--- a/container/crossbuild.containerfile
+++ b/container/crossbuild.containerfile
@@ -30,7 +30,7 @@ FROM $target_arch/$image
 WORKDIR /tmp
 
 # Copy repository configration files for apt
-COPY container/apt /etc/
+COPY container/apt/ /etc/apt/
 
 # Copy setup_native and pkgs into the container
 COPY container/conf/ ./


### PR DESCRIPTION
**What this PR does / why we need it**:

Really copy the apt configuration files into /etc/apt/, fix a mistake in previous changes. 

**Which issue(s) this PR fixes**:
Fixes #6 

