### PR TITLE
Add rsync package to containers for improved debian/ merge.

### DIFF
--- a/container/conf/pkgs
+++ b/container/conf/pkgs
@@ -16,5 +16,6 @@ lz4
 lzip
 lzop
 make
+rsync
 tar
 xz-utils


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #17 

**Special notes for your reviewer**:

Added `rsync` package installed inside the container image. So that we can use the same `rsync` method to merge `debian/` instead of replace `debian/`. This will be reducing the need for complete `debian/` replacements and minimizing unnecessary file changes in `debian/`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
