### PR TITLE
Feature/2 add support for native package builds

### DIFF
--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -14,6 +14,8 @@ main() (
 
 	if [[ "$source" = "git+"* ]]; then
 		git_source "${source#git+}"
+	elif [[ "$source" = "native" ]]; then
+		native_source
 	else
 		apt_source "$source"
 	fi
@@ -86,6 +88,11 @@ git_source() (
 	GIT_DIR=src.git git archive --prefix src/ "$ref" > orig.tar
 	rm -rf src.git
 	tar -x < orig.tar
+)
+
+native_source() (
+	echo "Native package build."
+	cp -r /input src
 )
 
 auto_decompress() (

--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -39,8 +39,10 @@ main() (
 	pkg="$(dpkg-parsechangelog --show-field Source)"
 	version="$(dpkg-parsechangelog --show-field Version)"
 	version_orig="${version%-*}"
-	xz < ../orig.tar > "../${pkg}_${version_orig}.orig.tar.xz"
-	rm ../orig.tar
+	if [ -f ../orig.tar ]; then
+		xz < ../orig.tar > "../${pkg}_${version_orig}.orig.tar.xz"
+		rm ../orig.tar
+	fi
 	
 	dpkg-source --build .
 
@@ -65,11 +67,17 @@ apt_source() (
 	orig=(*.orig.tar.*)
 	debian=(*.debian.tar.*)
 	dsc=(*.dsc)
-	auto_decompress "$orig" > orig.tar
-	mkdir src
-	tar -C src -x --strip-components 1 < orig.tar
-	auto_decompress "$debian" | tar -C src -xv
-	rm "$orig" "$debian" "$dsc"
+	dpkg-source --extract "$dsc" src
+	if [ -f "$orig" ]; then
+		auto_decompress "$orig" > orig.tar
+		rm $orig
+	else
+		rm *.tar.*
+	fi
+	if [ -f $debian ]; then
+		rm "$debian"
+	fi
+	rm "$dsc"
 )
 
 git_source() (


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2 

**Special notes for your reviewer**:
In `Gardenlinux`, there are two types of `native packages`: those directly sourced from `Debian`, such as `base-files`, and those specific to `Gardenlinux`, such as `gardenlinux-selinux-module`.

To accommodate these two types of native packages, two commits are proposed:

* Enhancing the `apt_source()` function:
The first commit aims to enhance the existing `apt_source()` function to support native packages sourced directly from Debian. This enhancement will enable the function to handle the retrieval and installation of native packages from the Debian repository.

* Adding the `native_source()` function:
The second commit involves adding the `native_source()` function to the codebase. This function will be triggered when the `pkg.yaml` file specifies `source: native` for a native package. The native_source() function will handle the necessary actions for handling `Gardenlinux-specific` native packages. Due to the `build_source` script already handles the source package name, so that we do not need to specific source package name but `native` is simply enough for our own native package support.

By introducing these commits, the `build_source` mechanism will be improved. It will no longer require explicitly specifying the source package name for native packages. Instead, using the keyword `native` will be sufficient to identify and support `Gardenlinux's own native packages`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
