### PR TITLE
Feature/15 enhance default variables management

### DIFF
--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -5,6 +5,13 @@ set -exuo pipefail
 exec 3>&1
 exec 1>&2
 
+# Default variables for build packages
+email="contact@gardenlinux.io"
+maintainer="Garden Linux Builder"
+distribution=gardenlinux
+message="Rebuild for Garden Linux."
+inputs_file="/input/.github/workflows/build.yml"
+
 main() (
 	DEB_BUILD_OPTIONS="terse $(yq -r '.build_options // ""' < "/input/pkg.yaml")"
 	export DEB_BUILD_OPTIONS
@@ -105,15 +112,16 @@ apply_patches() (
 		done < "$1/patches/series"
 	fi
 
+	name="$(yq -r '.name' < "$inputs_file")"
 	version="$(yq -r '.version // ""' < "$1/pkg.yaml")"
 	[ -n "$version" ] || version="$(dpkg-parsechangelog --show-field Version)"
-	email="$(yq -r '.email // ""' < "$1/pkg.yaml")"
-	name="$(yq -r '.name // ""' < "$1/pkg.yaml")"
-	distribution="$(yq -r '.distribution // ""' < "$1/pkg.yaml")"
+	email="$(yq -r --arg name "$name" '.jobs[$name].with.email // "'"$email"'"' < "$inputs_file")"
+	maintainer="$(yq -r --arg name "$name" '.jobs[$name].with.maintainer // "'"$maintainer"'"' < "$inputs_file")"
+	distribution="$(yq -r --arg name "$name" '.jobs[$name].with.distribution // "'"$distribution"'"' < "$inputs_file")"
 	version_suffix="$(yq -r '.version_suffix // ""' < "$1/pkg.yaml")"
-	message="$(yq -r '.message // ""' < "$1/pkg.yaml")"
+	message="$(yq -r --arg name "$name" '.jobs[$name].with.message // "'"$message"'"' < "$inputs_file")"
 
-	DEBEMAIL="$email" DEBFULLNAME="$name" dch --newversion "$version$version_suffix" --distribution "$distribution" --force-distribution -- "$message"
+	DEBEMAIL="$email" DEBFULLNAME="$maintainer" dch --newversion "$version$version_suffix" --distribution "$distribution" --force-distribution -- "$message"
 
 	if [ -x "$1/exec.post" ]; then
 		SOURCE="$source" "$1/exec.post"


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, we are introducing `build-defaults.yml` to handle `default variables` inside the `container image` for package build. 

**Which issue(s) this PR fixes**:
Fixes #15 

**Special notes for your reviewer**:
This enhancement aims to improve the local package build process by eliminating the need to specify common defaults repeatedly.

The addition of `build-defaults.yml` provides a centralized location for managing default variables, making it more convenient for local builds. Developers no longer have to explicitly define common defaults every time they build packages.

Furthermore, these default variables can be overridden with variables specified in `pkg.yaml` and also possible from GitHub Action workflows `build.yml` file for both workflow and local builds as well.

For instance, in the provided example for the workflow builds(also works the same for local builds):
```
name: htop
on: push
jobs:
  htop:
    uses: gardenlinux/package-build/.github/workflows/build_pkg.yml@main
    with:
      email: "which@you.want"
      maintainer: "Other than default"
      distribution: whatever
      message: "Specified message."
```
And it's build results:
```
Format: 1.8
Date: Thu, 23 Nov 2023 11:42:15 +0000
Source: htop
Binary: htop htop-dbgsym
Architecture: arm64
Version: 3.2.2-2gl0
Distribution: whatever
Urgency: medium
Maintainer: Daniel Lange <DLange@debian.org>
Changed-By: Other than default <which@you.want>
Description:
 htop       - interactive processes viewer
Changes:
 htop (3.2.2-2gl0) whatever; urgency=medium
 .
   * Specified message.
```
The variables `email`, `maintainer`, `distribution`, and `message` can be customized for specific workflows, allowing fine-grained control over the package build process.

This enhancement supports `both` GitHub `Action workflows` and `local builds`, providing `flexibility` and `consistency` across different environments.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
