### PR TITLE
Ensure that testing is the default distro for fetching sources

### DIFF
--- a/container/apt/apt.conf.d/00default-release
+++ b/container/apt/apt.conf.d/00default-release
@@ -1,0 +1,1 @@
+APT::Default-Release "testing";


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that testing is the default distro for fetching sources

**Which issue(s) this PR fixes**:
Fixes #31 

