### PR TITLE
Add build workflow parameter `build_profiles` for changing the build profiles

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -11,6 +11,12 @@ on:
       build_container:
         type: string
         default: ghcr.io/gardenlinux/package-build
+      build_options:
+        type: string
+        default: ""
+      build_profiles:
+        type: string
+        default: ""
       source:
         type: string
         default: ""
@@ -40,6 +46,7 @@ jobs:
       source_name: ${{ steps.build.outputs.source_name }}
       source_version: ${{ steps.build.outputs.source_version }}
       build_options: ${{ steps.build.outputs.build_options }}
+      build_profiles: ${{ steps.build.outputs.build_profiles }}
       release: ${{ steps.release.outputs.release }}
     runs-on: ubuntu-latest
     steps:
@@ -86,6 +93,7 @@ jobs:
           )"
           echo "pkg=$pkg" | tee -a "$GITHUB_OUTPUT"
           echo "build_options=$(cat output/.build_options)" | tee -a "$GITHUB_OUTPUT"
+          echo "build_profiles=$(cat output/.build_profiles)" | tee -a "$GITHUB_OUTPUT"
           echo "source_name=$(cat output/.source_name)" | tee -a "$GITHUB_OUTPUT"
           echo "source_version=$(cat output/.source_version)" | tee -a "$GITHUB_OUTPUT"
       - name: upload source packages
@@ -125,6 +133,7 @@ jobs:
         run: |
           cd input/
           echo "${{ needs.source.outputs.build_options }}" > .build_options
+          echo "${{ needs.source.outputs.build_profiles}}" > .build_profiles
           ln -s "${{ needs.source.outputs.pkg }}.dsc" .source
       - name: fetch dependencies
         run: |

--- a/container/bin/build_archdep
+++ b/container/bin/build_archdep
@@ -8,7 +8,9 @@ exec 1>&2
 main() (
 	input_dir="${1:-/input}"
 	DEB_BUILD_OPTIONS="$(cat "$input_dir/.build_options")"
+	DEB_BUILD_PROFILES="$(cat "$input_dir/.build_profiles")"
 	export DEB_BUILD_OPTIONS
+	export DEB_BUILD_PROFILES
 
 	dsc="$(realpath "$input_dir/.source")"
 	dpkg_arch="$(dpkg --print-architecture)"

--- a/container/bin/build_indep
+++ b/container/bin/build_indep
@@ -8,7 +8,9 @@ exec 1>&2
 main() (
 	input_dir="${1:-/input}"
 	DEB_BUILD_OPTIONS="$(cat "$input_dir/.build_options")"
+	DEB_BUILD_PROFILES="$(cat "$input_dir/.build_profiles")"
 	export DEB_BUILD_OPTIONS
+	export DEB_BUILD_PROFILES
 
 	dsc="$(realpath "$input_dir/.source")"
 	dsc_arch="$(grep -oP '(?<=^Architecture: ).*' < "$dsc" | tr ' ' '\n')"

--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -19,9 +19,11 @@ main() (
 	source="$(yq -r '.jobs.build_pkg.with.source // "'$name'"' < "$inputs_file")"
 	debian_source="$(yq -r '.jobs.build_pkg.with.debian_source // "'$debian_source'"' < "$inputs_file")"
 	build_options="terse $(yq -r '.jobs.build_pkg.with.build_options // ""' < "$inputs_file")"
+	build_profiles="$(yq -r '.jobs.build_pkg.with.build_profiles // ""' < "$inputs_file")"
 
 	# Define Build Options
 	export DEB_BUILD_OPTIONS="$build_options"
+	export DEB_BUILD_PROFILES="$build_profiles"
 
 	# Set permissions
 	git -C /input config --global --add safe.directory '*'
@@ -64,13 +66,14 @@ main() (
 
 	# Add some meta files next to the created artifacts
 	echo "$DEB_BUILD_OPTIONS" > .build_options
+	echo "$DEB_BUILD_PROFILES" > .build_profiles
 	echo "${pkg}" > .source_name
 	echo "${version}" > .source_version
 	ln -s "${pkg}_${version}.dsc" .source
 
 	# Copy all artifacts to the dedicated output directory
 	if [ -d "/output" ]; then
-		{ echo .build_options; echo .source_name; echo .source_version; echo .source; echo "${pkg}_${version}.dsc"; get_files < "${pkg}_${version}.dsc"; } | while read file; do
+		{ echo .build_options; echo .build_profiles; echo .source_name; echo .source_version; echo .source; echo "${pkg}_${version}.dsc"; get_files < "${pkg}_${version}.dsc"; } | while read file; do
 			sudo cp -d "$file" "/output/$file"
 		done
 	fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Add build workflow parameter `build_profiles` for adding the support of changing the build profiles during a package build.

**Which issue(s) this PR fixes**:
Fixes #26 