### PR TITLE
Handle version with epoch.

### DIFF
--- a/container/bin/build_archdep
+++ b/container/bin/build_archdep
@@ -25,18 +25,20 @@ main() (
 	cd src
 	pkg="$(dpkg-parsechangelog --show-field Source)"
 	version="$(dpkg-parsechangelog --show-field Version)"
+	# Use package's version name without epoch
+	pkg_version="${version#*:}"
 	dpkg-buildpackage --no-sign --build=any
 	cd ..
 	rm -rf src
 	ls -lah
 
 	if [ -d "/output" ]; then
-		{ echo "${pkg}_${version}_${dpkg_arch}.changes"; get_files < "${pkg}_${version}_${dpkg_arch}.changes"; } | while read file; do
+		{ echo "${pkg}_${pkg_version}_${dpkg_arch}.changes"; get_files < "${pkg}_${pkg_version}_${dpkg_arch}.changes"; } | while read file; do
 			sudo cp -d "$file" "/output/$file"
 		done
 	fi
 
-	echo "${pkg}_${version}_${dpkg_arch}" >&3
+	echo "${pkg}_${pkg_version}_${dpkg_arch}" >&3
 )
 
 get_files() (

--- a/container/bin/build_indep
+++ b/container/bin/build_indep
@@ -24,18 +24,20 @@ main() (
 	cd src
 	pkg="$(dpkg-parsechangelog --show-field Source)"
 	version="$(dpkg-parsechangelog --show-field Version)"
+	# Use package's version name without epoch
+	pkg_version="${version#*:}"
 	dpkg-buildpackage --no-sign --build=all
 	cd ..
 	rm -rf src
 	ls -lah
 
 	if [ -d "/output" ]; then
-		{ echo "${pkg}_${version}_all.changes"; get_files < "${pkg}_${version}_all.changes"; } | while read file; do
+		{ echo "${pkg}_${pkg_version}_all.changes"; get_files < "${pkg}_${pkg_version}_all.changes"; } | while read file; do
 			sudo cp -d "$file" "/output/$file"
 		done
 	fi
 
-	echo "${pkg}_${version}_all" >&3
+	echo "${pkg}_${pkg_version}_all" >&3
 )
 
 get_files() (

--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -53,6 +53,9 @@ main() (
 
 	pkg="$(dpkg-parsechangelog --show-field Source)"
 	version="$(dpkg-parsechangelog --show-field Version)"
+	# Version for the orig tarball should not contains epoch
+	version="${version#*:}"
+	# Version for the orig tarball should not contains revision
 	version_orig="${version%-*}"
 	if [ -f ../orig.tar ]; then
 		xz < ../orig.tar > "../${pkg}_${version_orig}.orig.tar.xz"
@@ -70,18 +73,20 @@ main() (
 	echo "$DEB_BUILD_OPTIONS" > .build_options
 	echo "$DEB_BUILD_PROFILES" > .build_profiles
 	echo "${pkg}" > .source_name
-	echo "${version}" > .source_version
-	ln -s "${pkg}_${version}.dsc" .source
+	# The package version should not contains epoch
+	pkg_version="${version#*:}"
+	echo "${pkg_version}" > .source_version
+	ln -s "${pkg}_${pkg_version}.dsc" .source
 
 	# Copy all artifacts to the dedicated output directory
 	if [ -d "/output" ]; then
-		{ echo .build_options; echo .build_profiles; echo .source_name; echo .source_version; echo .source; echo "${pkg}_${version}.dsc"; get_files < "${pkg}_${version}.dsc"; } | while read file; do
+		{ echo .build_options; echo .build_profiles; echo .source_name; echo .source_version; echo .source; echo "${pkg}_${pkg_version}.dsc"; get_files < "${pkg}_${pkg_version}.dsc"; } | while read file; do
 			sudo cp -d "$file" "/output/$file"
 		done
 	fi
 
 	# Finally, print the package name and version
-	echo "${pkg}_${version}" >&3
+	echo "${pkg}_${pkg_version}" >&3
 )
 
 apt_source() (


### PR DESCRIPTION
**What this PR does / why we need it**:

The current workflow cannot not find the orig tarball due to package version contains epoch. This fix trims out the epoch for source and binary package file name.

**Which issue(s) this PR fixes**:
Fixes #42 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
