### PR TITLE
Replace epoch colon : with a percent sign % in the tag.

### DIFF
--- a/scripts/gh_release
+++ b/scripts/gh_release
@@ -65,6 +65,8 @@ case "$action" in
 		name="$1"; shift
 
 		normalized_tag=${tag/\~/\_}
+		# Replace epoch colon ":" with a percent sign "%" in the tag.
+		normalized_tag=${normalized_tag/\:/\%}
 
 		release="$(post "releases" '{
 			"draft": '"$draft"',

--- a/scripts/gh_release
+++ b/scripts/gh_release
@@ -64,7 +64,8 @@ case "$action" in
 		commit="$1"; shift
 		name="$1"; shift
 
-		normalized_tag=${tag/\~/\_}
+		# Replace all the tilde "~" with "_" underscore in the tag.
+		normalized_tag=${tag//\~/_}
 		# Replace epoch colon ":" with a percent sign "%" in the tag.
 		normalized_tag=${normalized_tag/\:/\%}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes the package version contains `epoch` colon `:` with a percent sign `%` when tagging in git.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
