### PR TITLE
Find another way to determine the git branch

### DIFF
--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -248,7 +248,7 @@ get_version() (
 	if [ -z $version ]; then
 		package_version=$(get_upstream_version $source)
 		git_commit_hash=$(git -C /input rev-parse HEAD)
-		git_branch=$(git -C /input branch --show-current)
+		git_branch=$(git -C /input name-rev --name-only --refs="refs/heads/*" HEAD)
 		git_tags=$(git -C /input tag)
 
 		# No version has been provided. Check if there is already a gardenlinux0 version.


### PR DESCRIPTION
**What this PR does / why we need it**:
The method of determining the git branch in the `build_source` script didn't work if the git checkout is in detached mode. The new method is more stable for this scenario

**Which issue(s) this PR fixes**:
Fixes #54 
