### PR TITLE
Feature/61 re use repository and ref parameter

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -2,12 +2,9 @@ name: build
 on:
   workflow_call:
     inputs:
-      repository:
-        type: string
-        default: ${{ github.repository }}
       ref:
         type: string
-        default: ${{ github.sha }}
+        default: main
       build_container:
         type: string
         default: ghcr.io/gardenlinux/package-build
@@ -59,11 +56,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: gardenlinux/package-build
+          ref: ${{ inputs.ref }}
       - run: mkdir input output
       - uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.repository }}
-          ref: ${{ inputs.ref }}
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
           path: input
           fetch-tags: true
           fetch-depth: 0
@@ -125,6 +123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: gardenlinux/package-build
+          ref: ${{ inputs.ref }}
       - name: setup binfmt
         if: ${{ matrix.arch == 'arm64v8' }}
         run: sudo podman run --privileged ghcr.io/gardenlinux/binfmt_container
@@ -190,6 +189,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: gardenlinux/package-build
+          ref: ${{ inputs.ref }}
       - name: check if ${{ env.pkg }} already released
         id: check
         run: |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -49,8 +49,7 @@ The `build_pkg.yml` workflow can be triggered by calling it with specific input 
 Input Parameters available in `build_pkg.yml`:
 | Parameter | Type | Description |
 | --------- | ---- | ------------|
-|`repository`|**Type:** string<br>**Default:** `${{ github.repository }}`| The repository to build the package from.|
-|`ref`|**Type:** string<br>**Default:** `${{ github.sha }}`| The ref (commit or branch) to build the package from.|
+|`ref`|**Type:** string<br>**Default:** `${{ github.sha }}`| The ref (commit or branch) that should be checked out from the `package-build` repo while processing the package build.|
 |`build_container`|**Type:** string<br>**Default:** `ghcr.io/gardenlinux/package-build`| The container image used for building the package.|
 |`dependencies`|**Type:** string| Comma-separated list of repositories and tags to fetch dependencies from.|
 |`source`|**Type:** string| The source name of the package. There are three values that one can choose from:<br>- Debian Source Package: `{SOURCE PACKAGE NAME}`<br>- Git Source: `git+{GIT URL}`<br>- Native Build: `native`|


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the `repository` parameter and make the `package-build` reference configurable via the `ref` parameter

**Which issue(s) this PR fixes**:
Fixes #61 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
