### PR TITLE
Add same git clone options that we used to have in gitlab-ci.

### DIFF
--- a/container/bin/build_source
+++ b/container/bin/build_source
@@ -109,7 +109,7 @@ apt_source() (
 
 git_source() (
 	IFS='#' read -r url ref <<< "$1"
-	git clone "$url" src.git
+	git clone --jobs $(nproc) --shallow-submodules --recurse-submodules "$url" src.git
 	git -C src.git archive --prefix src/ "$(get_git_tag)" > orig.tar
 	rm -rf src.git
 	tar -x < orig.tar


### PR DESCRIPTION
**What this PR does / why we need it**:
For building `aws-sdk-cpp`, we need `--recurse-submodules` options.
Checked our gitlab-ci and found we should add these options into the git clone:
```
--jobs $(nproc) --shallow-submodules --recurse-submodules
```

Details:
https://gitlab.com/gardenlinux/gardenlinux-package-build/-/blob/main/pipeline/source-git.yml?ref_type=heads#L58

**Which issue(s) this PR fixes**:
Fixes #67 
